### PR TITLE
chore: add nyc for coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 *\.sh
 /node_modules
 /npm-debug.log
+.nyc_output
+coverage

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,8 @@
+{
+  "all": true,
+  "cache": false,
+  "reporter": [
+    "lcov",
+    "text"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "eslint-fix": "eslint --fix ./lib/utils.js ./test",
     "babel": "babel src --out-dir lib",
     "pub": "npm run babel && npm publish && rm -rf lib",
-    "test": "mocha"
+    "test": "nyc mocha"
   },
   "babel": {
     "presets": [
@@ -40,6 +40,7 @@
     "babel-preset-es2015": "^6.6.0",
     "eslint": "^2.10.2",
     "eslint-config-egg": "^2.0.0",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "nyc": "^11.6.0"
   }
 }


### PR DESCRIPTION
Add [nyc](https://github.com/istanbuljs/nyc) (Istanbul command-line interface) to generate coverage reports. With the minimal integration, coverage information will be logged after running tests. This helps to visualize current coverage and areas in need of tests.

```sh
$ npm test
```

![screen shot 2018-04-14 at 1 11 47 pm](https://user-images.githubusercontent.com/4885634/38770727-76c36812-3fe5-11e8-9a53-8ac0331d5fcc.png)

