### PR TITLE
fix: prevent mutation if fragment param when appending

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -91,11 +91,11 @@ exports.appendChild = function appendChild(parent, child) {
 
   if (isArray(child) && child[0] === '') {
     // result was multiple JsonML sub-trees (i.e. documentFragment)
-    child.shift();// remove fragment ident
+    const fragments = child.slice(1);
 
     // directly append children
-    while (child.length) {
-      appendChild(parent, child.shift(), arguments[2]);
+    while (fragments.length) {
+      appendChild(parent, fragments.shift(), arguments[2]);
     }
 
   } else if (child && 'object' === typeof child) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -262,15 +262,17 @@ describe('utils', function() {
         assert.deepEqual(jml, ['div', ['em', 'hello'], ['strong', 'world']]);
       });
 
-      // @TODO - is this an intentional mutation?
-      it('should remove fragment contents', function() {
+      it('should not mutate child fragment param', function() {
         const jml = ['div'];
         const fragment = ['',
           ['em', 'hello'],
           ['strong', 'world'],
         ];
         utils.appendChild(jml, fragment);
-        assert.deepEqual(fragment, []);
+        assert.deepEqual(fragment, ['',
+          ['em', 'hello'],
+          ['strong', 'world'],
+        ]);
       });
     });
 


### PR DESCRIPTION
Fixes issue filed upstream as https://github.com/benjycui/jsonml.js/issues/7

Prevents mutation of a fragment when passed to `utils.appendChild`