### PR TITLE
fix: use html.isRaw method when appending child Markup instances

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const isRaw = require('./html').isRaw;
+
 const isArray = Array.isArray || function isArray(val) {
   return val instanceof Array;
 };
@@ -110,7 +112,7 @@ exports.appendChild = function appendChild(parent, child) {
       // result was a JsonML node
       parent.push(child);
 
-    } else if (exports.isRaw(child)) {
+    } else if (isRaw(child)) {
 
       // result was a JsonML node
       parent.push(child);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const html = require('../lib/html');
 const utils = require('../lib/utils');
 
 describe('utils', function() {
@@ -311,18 +312,16 @@ describe('utils', function() {
     });
 
     describe('when appending a raw child', function() {
-      // @TODO - this will currently throw an error due to missing function `isRaw`
-      xit('should append to the parent', function() {
+      it('should append to the parent', function() {
         const jml = ['div'];
-        const child = new function RawChild() {};
+        const child = html.raw('string value');
         utils.appendChild(jml, child);
-        assert.strictEqual(jml, ['div', child]);
+        assert.deepEqual(jml, ['div', child]);
       });
     });
 
     describe('when appending attributes', function() {
-      // @TODO - this will currently throw an error due to missing function `isRaw`
-      xit('should add attributes to the parent element', function() {
+      it('should add attributes to the parent element', function() {
         const jml = ['div'];
         const attrs = { a: 1 };
         utils.appendChild(jml, attrs);


### PR DESCRIPTION
Fixes issue filed upstream as https://github.com/benjycui/jsonml.js/issues/9

- Use `isRaw` from `html` interface

This fixes the error thrown when `isRaw` is `undefined`