### PR TITLE
Post coverage data to Coveralls after travis success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ node_js:
 
 notifications:
   email: false
+
+after_success:
+  # Deploy coverage reports to Coveralls for node 8 run
+  - if [[ $(node -v) == v8* ]]; then npm install coveralls; ./node_modules/.bin/coveralls < coverage/lcov.info; fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # jsonml.js
 
 [![Build Status](https://travis-ci.org/CondeNast/jsonml.js.svg?branch=master)](https://travis-ci.org/CondeNast/jsonml.js)
+[![Coverage Status](https://coveralls.io/repos/github/CondeNast/jsonml.js/badge.svg)](https://coveralls.io/github/CondeNast/jsonml.js)
 
 JsonML-related tools.
 


### PR DESCRIPTION
Based on: https://github.com/CondeNast/xml-to-react/pull/6

## Description
- Modified travis-ci config
  After success on the node 8 test run (only):
  - install [`coveralls`](https://github.com/nickmerwin/node-coveralls) module
  - post lcov report to Coveralls
- Added Coveralls badge to README 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore, documentation, cleanup

## Related Issue
n/a

## Motivation and Context
Coverage reports are always helpful for visualizing the current state of tests

## How Has This Been Tested?
This PR build successfully sent coverage data:
https://coveralls.io/github/CondeNast/xml-to-react


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.
