### PR TITLE
chore: run lint before tests and fix eslint issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@
 module.exports = {
   extends: 'eslint-config-egg',
   rules: {
+    'array-bracket-spacing': ['error', 'never'],
     yoda: 'off'
   }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -128,7 +128,7 @@ const addAttributes = exports.addAttributes = function addAttributes(jml, attr) 
 
   // merge attribute objects
   const old = jml[1];
-  for (let key in attr) {
+  for (const key in attr) {
     if (attr.hasOwnProperty(key)) {
       old[key] = attr[key];
     }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prebuild": "rm -rf dist",
     "build": "babel lib --out-dir dist",
     "prepublishOnly": "babel lib --out-dir dist",
+    "pretest": "npm run lint",
     "test": "nyc mocha"
   },
   "keywords": [

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -131,7 +131,7 @@ describe('dom', function() {
 
     it('should allow a filter param to modify the returned JsonML node', function() {
       const html = '<div>hello</div>';
-      const jml = dom.fromHTMLText(html, (jml) => {
+      const jml = dom.fromHTMLText(html, jml => {
         jml[0] = 'foo';
         return jml;
       });

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -5,12 +5,15 @@ const jsdom = require('jsdom').jsdom;
 const html = require('../lib/html');
 
 describe('html', function() {
+  let document;
+
   before(function() {
-    global.document = jsdom();
+    document = global.document = jsdom();
   });
 
   after(function() {
     delete global.document;
+    document = null;
   });
 
   describe('raw', function() {
@@ -67,7 +70,7 @@ describe('html', function() {
       const elem = document.createElement('div');
       const jml = ['div', { id: 'a1' },
         'hello ',
-        ['span', 'world']
+        ['span', 'world'],
       ];
       html.patch(elem, jml);
       assert.equal(elem.outerHTML, '<div id="a1">hello <span>world</span></div>');
@@ -142,7 +145,7 @@ describe('html', function() {
     it('should create a DOM element for JsonML node with children', function() {
       const jml = ['span', { 'data-foo': 'bar' },
         'hello ',
-        ['strong', 'world']
+        ['strong', 'world'],
       ];
       const elem = html.toHTML(jml);
       assert.equal(elem.outerHTML, '<span data-foo="bar">hello <strong>world</strong></span>');
@@ -167,7 +170,7 @@ describe('html', function() {
     it('should create an html string from a JsonML node with children', function() {
       const jml = ['span', { 'data-foo': 'bar' },
         'hello ',
-        ['strong', 'world']
+        ['strong', 'world'],
       ];
       const text = html.toHTMLText(jml);
       assert.equal(text, '<span data-foo="bar">hello <strong>world</strong></span>');

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -292,7 +292,7 @@ describe('utils', function() {
       });
 
       it('should append element with all descendents', function() {
-        const jml = ['div', { a: 1}];
+        const jml = ['div', { a: 1 }];
         const subtree = ['section',
           ['p', 'hello'],
           ['p', 'world'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Ensure that eslint is run before tests locally and during travis jobs
- Override rule `array-bracket-spacing` to `never`, to be consistent with the library, and especially to better adhere to expected JsonML structures
- Fix minor issues

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore, documentation, cleanup

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
n/a

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
