### PR TITLE
refactor(dom,html): use constants for nodeType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Update jsdom to v16, used in the DOM interface for using JsonML to interact with the DOM.
-
+- Use constants when comparing nodeType
 
 [#28]: https://github.com/CondeNast/jsonml.js/pull/28
 

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -54,9 +54,9 @@ var fromHTML = exports.fromHTML = function(elem, filter) {
 
   var i, jml;
   switch (elem.nodeType) {
-    case 1:  // element
-    case 9:  // document
-    case 11: // documentFragment
+    case win.Node.ELEMENT_NODE:
+    case win.Node.DOCUMENT_NODE:
+    case win.Node.DOCUMENT_FRAGMENT_NODE:
       jml = [elem.tagName.toLowerCase()||''];
 
       var attr = elem.attributes,
@@ -152,13 +152,13 @@ var fromHTML = exports.fromHTML = function(elem, filter) {
       // free references
       elem = null;
       return jml;
-    case 3: // text node
-    case 4: // CDATA node
+    case win.Node.TEXT_NODE:
+    case win.Node.CDATA_SECTION_NODE:
       var str = String(elem.nodeValue);
       // free references
       elem = null;
       return /^(\n|\s)+$/.test(str) ? null : str;
-    case 10: // doctype
+    case win.Node.DOCUMENT_TYPE_NODE:
       jml = ['!'];
 
       var type = ['DOCTYPE', (elem.name || 'html').toLowerCase()];
@@ -181,7 +181,7 @@ var fromHTML = exports.fromHTML = function(elem, filter) {
       // free references
       elem = null;
       return jml;
-    case 8: // comment node
+    case win.Node.COMMENT_NODE:
       if ((elem.nodeValue||'').indexOf('DOCTYPE') !== 0) {
         // free references
         elem = null;
@@ -205,9 +205,10 @@ var fromHTML = exports.fromHTML = function(elem, filter) {
   }
 };
 
-const doc = typeof document === 'undefined' ?
-      (new JSDOM()).window.document :
-      document;
+const win = typeof window === 'undefined' ?
+  (new JSDOM()).window :
+  window;
+const doc = win.document;
 
 /**
  * Generate a JsonML tree from an HTML string

--- a/lib/html.js
+++ b/lib/html.js
@@ -474,14 +474,14 @@ var addAttributes = function(elem, attr) {
 var appendDOM = function(elem, child) {
   if (child) {
     var tag = (elem.tagName||'').toLowerCase();
-    if (elem.nodeType === 8) { // comment
-      if (child.nodeType === 3) { // text node
+    if (elem.nodeType === window.Node.COMMENT_NODE) {
+      if (child.nodeType === window.Node.TEXT_NODE) {
         elem.nodeValue += child.nodeValue;
       }
     } else if (tag === 'table' && elem.tBodies) {
       if (!child.tagName) {
         // must unwrap documentFragment for tables
-        if (child.nodeType === 11) {
+        if (child.nodeType === window.Node.DOCUMENT_FRAGMENT_NODE) {
           while (child.firstChild) {
             appendDOM(elem, child.removeChild(child.firstChild));
           }
@@ -550,7 +550,7 @@ var appendDOM = function(elem, child) {
  * @return {boolean} true if whitespace
  */
 var isWhitespace = function(node) {
-  return !!node && (node.nodeType === 3) && (!node.nodeValue || !/\S/.exec(node.nodeValue));
+  return !!node && (node.nodeType === window.Node.TEXT_NODE) && (!node.nodeValue || !/\S/.exec(node.nodeValue));
 };
 
 /**
@@ -562,7 +562,7 @@ var isWhitespace = function(node) {
  * @return {undefined} undefined
  */
 var trimPattern = function(node, pattern) {
-  if (!!node && (node.nodeType === 3) && pattern.exec(node.nodeValue)) {
+  if (!!node && (node.nodeType === window.Node.TEXT_NODE) && pattern.exec(node.nodeValue)) {
     node.nodeValue = node.nodeValue.replace(pattern, '');
   }
 };
@@ -642,8 +642,7 @@ exports.onerror = null;
  * @return {Node} DOM Node
  */
 var patch = exports.patch = function(elem, jml, filter) {
-  // Cannot patch text nodes
-  if (elem.nodeType === 3) {
+  if (elem.nodeType === window.Node.TEXT_NODE) {
     return elem;
   }
 
@@ -655,7 +654,7 @@ var patch = exports.patch = function(elem, jml, filter) {
     } else if (isMarkup(jml[i])) {
       appendDOM(elem, toDOM(jml[i].value));
 
-    } else if ('object' === typeof jml[i] && jml[i] !== null && elem.nodeType === 1) {
+    } else if ('object' === typeof jml[i] && jml[i] !== null && elem.nodeType === window.Node.ELEMENT_NODE) {
       // add attributes
       elem = addAttributes(elem, jml[i]);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Using constants from the Node API
See: https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType

- NOTE: The `html` package is still intended to be running within an implicit browser- or DOM-compatible environment.
- The `dom` package will fack

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore, documentation, cleanup

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This makes the code much clearer and allows removing comments / maintaining "magic numbers"

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
