### PR TITLE
docs: Identify jsdom v16 update as breaking due to node 10+ requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Breaking
+- Update jsdom to v16, used in the DOM interface for using JsonML to interact with the DOM.
+  BREAKING CHANGE
+  jsdom requires node version 10 or greater
+
 ### Fixed
 - Ensure valid table structure when creating or updating elements when
   using the `toHTML()` or `patch()` methods ([#28])
 
 ### Changed
-- Update jsdom to v16, used in the DOM interface for using JsonML to interact with the DOM.
 - Use constants when comparing nodeType
 
 [#28]: https://github.com/CondeNast/jsonml.js/pull/28


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- `jsdom@16.x` requires node 10+
- #20 was not marked as a breaking change and should have been (I've updated the checkboxes on that PR)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore, documentation, cleanup

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This helps indicate that `master` now contains a BREAKING CHANGE. The next release should be a major version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->
n/a

## Screenshots (if appropriate):
n/a

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
