### PR TITLE
fix(dom): Maintain empty spaces in text nodes when converting from HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- (dom): Maintain empty spaces in text nodes when converting from HTML.
+   Reverts an upstream change ([24f5ce7]) that modified McKamey's original logic.
+   Fixes methods `fromHTML` and `fromHTMLText`.
+
+[24f5ce7]: https://github.com/benjycui/jsonml.js/commit/24f5ce7a0da83f445865a1188744c238111ac5ac
+
 ## Version 2.1.0 - 2020-03-25
 ### Changed
 - (utils): Allow raw Markup instances to self-identify with isMarkup prop (#33)

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -157,7 +157,7 @@ var fromHTML = exports.fromHTML = function(elem, filter) {
       var str = String(elem.nodeValue);
       // free references
       elem = null;
-      return /^(\n|\s)+$/.test(str) ? null : str;
+      return str;
     case win.Node.DOCUMENT_TYPE_NODE:
       jml = ['!'];
 

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -162,6 +162,17 @@ describe('dom', function() {
         ['span', 'bar'],
       ]);
     });
+
+    it('should maintain spaces between adjacent inline elements', function() {
+      doc.body.innerHTML = '<div id="my-div"><em>foo</em> <em>bar</em></div>';
+      const elem = doc.getElementById('my-div');
+      const jml = dom.fromHTML(elem);
+      assert.deepEqual(jml, ['div', { id: 'my-div' },
+        ['em', 'foo'],
+        ' ',
+        ['em', 'bar'],
+      ]);
+    });
   });
 
   describe('fromHTMLText', function() {
@@ -198,6 +209,16 @@ describe('dom', function() {
         return jml;
       });
       assert.deepEqual(jml, ['foo', 'hello']);
+    });
+
+    it('should maintain spaces between adjacent inline elements', function() {
+      const html = '<p><em>foo</em> <em>bar</em></p>';
+      const jml = dom.fromHTMLText(html);
+      assert.deepEqual(jml, ['p',
+        ['em', 'foo'],
+        ' ',
+        ['em', 'bar'],
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Description

Capture spaces between elements, e.g. `<em>a</em> <em>b</em>` has a space in between. This was being omitted when using `fromHTML` and `fromHTMLText`.

Reverts an upstream change ([24f5ce7]) that modified McKamey's original logic.
Original source material: https://raw.githubusercontent.com/mckamey/jsonml/master/jsonml-dom.js

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore, documentation, cleanup

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
n/a

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):
n/a

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
