### PR TITLE
fix(package): export interface namespaces in addition to merged methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ Determine if a JsonML node has attributes
 
 ### XML
 
+```js
+const { xml } = require('@condenast/jsonml.js');
+```
+
 #### `fromXML( elem, filter )`
 
 Converts XML nodes to JsonML

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,22 @@
 'use strict';
 
-const utils = require('./utils');
 const dom = require('./dom');
 const html = require('./html');
+const utils = require('./utils');
 const xml = require('./xml');
-Object.assign(module.exports, utils, dom, html, xml);
+
+const namespaces = {
+  dom,
+  html,
+  utils,
+  xml,
+};
+
+// Export all methods and namespaced interfaces
+Object.assign(module.exports,
+  namespaces,
+  dom,
+  html,
+  utils,
+  xml
+);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,8 +8,20 @@ const xml = require('../lib/xml');
 const utils = require('../lib/utils');
 
 describe('JsonML module index', function() {
-  it('should merge and export interfaces', function() {
-    assert.deepEqual(JsonML, Object.assign({}, dom, html, xml, utils));
+  it('should export the dom namespace', function() {
+    assert.deepEqual(JsonML.dom, dom);
+  });
+
+  it('should export the html namespace', function() {
+    assert.deepEqual(JsonML.html, html);
+  });
+
+  it('should export the xml namespace', function() {
+    assert.deepEqual(JsonML.xml, xml);
+  });
+
+  it('should export the utils namespace', function() {
+    assert.deepEqual(JsonML.utils, utils);
   });
 
   it('should export all methods from the dom interface', function() {


### PR DESCRIPTION
## Description

Currently all methods are being merged into the top-level export from the module. It would be really helpful to export the individual namespaces. The existing documentation already implies this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore, documentation, cleanup

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- the docs and source are out of sync
- the distributed package could be a bit difficult to use, given so many methods and only needing a subset

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
